### PR TITLE
Enable WiFiUDP for Beken-72XX

### DIFF
--- a/arduino/beken-72xx/libraries/WiFi/WiFi.h
+++ b/arduino/beken-72xx/libraries/WiFi/WiFi.h
@@ -8,3 +8,4 @@
 #include "WiFiClient.h"
 #include "WiFiClientSecure.h"
 #include "WiFiServer.h"
+#include "WiFiUdp.h"


### PR DESCRIPTION
As the title says, one-liner