### PR TITLE
[beken-72xx] Fix GPIO deep sleep wakeup edge

### DIFF
--- a/cores/beken-72xx/base/api/lt_sleep.c
+++ b/cores/beken-72xx/base/api/lt_sleep.c
@@ -9,9 +9,9 @@ void lt_deep_sleep_config_gpio(uint32_t gpio_index_map, bool on_high) {
 	deep_sleep_param.wake_up_way |= PS_DEEP_WAKEUP_GPIO;
 	deep_sleep_param.gpio_index_map |= gpio_index_map;
 	if (on_high) {
-		deep_sleep_param.gpio_edge_map &= (~gpio_index_map);
-	} else {
 		deep_sleep_param.gpio_edge_map |= gpio_index_map;
+	} else {
+		deep_sleep_param.gpio_edge_map &= (~gpio_index_map);
 	}
 }
 


### PR DESCRIPTION
Manufacturer docs: https://docs-bekencorp-com.translate.goog/sdk_3.0.x/bk7238/html/developer-guide/power_save/sleep_test.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=hu&_x_tr_pto=wapp

Discussion: https://github.com/libretiny-eu/libretiny-esphome/pull/11